### PR TITLE
ADD: 유효성 검사 추가

### DIFF
--- a/public/data/likeData.json
+++ b/public/data/likeData.json
@@ -1,24 +1,28 @@
 {
   "data": [
     {
+      "cafe_id": 1,
       "name": "달달한 커피",
       "address": "서울시 강북구 ㅇㅇ로 123-12",
       "score": 3,
       "url": "/images/1.png"
     },
     {
+      "cafe_id": 3,
       "name": "24시 카페 ",
       "address": "인천시 서구 ㅇㅇ동 234-87",
       "score": 4.5,
       "url": "/images/2.jpeg"
     },
     {
+      "cafe_id": 5,
       "name": "편리한 스터디까페 ",
       "address": "경기도 부천시 원미구 중3동 123-92",
       "score": 1,
       "url": "/images/3.png"
     },
     {
+      "cafe_id": 4,
       "name": "자동카페",
       "address": "서울시 강남구 테헤란로 123-15",
       "score": 2.5,

--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -21,6 +21,7 @@ to {
 const Nav = () => {
   const [isLeftOpen, setIsLeftOpen] = useState(false);
   const [isRightOpen, setIsRightOpen] = useState(false);
+  const [isLocationName, setIsLocationName] = useState('');
 
   const leftSideRef = useRef(null);
   const rightSideRef = useRef(null);
@@ -57,7 +58,7 @@ const Nav = () => {
         <LeftSidebarWrapper isLeftOpen={isLeftOpen} ref={leftSideRef}>
           {isLeftOpen && <IntroduceSidebar setIsLeftOpen={setIsLeftOpen} />}
         </LeftSidebarWrapper>
-        <LocationName>현재 위치의 지역명</LocationName>
+        {isLocationName && <LocationName>현재 위치의 지역명</LocationName>}
 
         {!refreshToken ? (
           <LoginBtn onClick={() => setIsRightOpen(true)}>로그인</LoginBtn>

--- a/src/pages/Cafe/CafeList.jsx
+++ b/src/pages/Cafe/CafeList.jsx
@@ -10,35 +10,40 @@ const CafeList = ({ cafeData }) => {
 
   //좋아요 클릭시 백에 데이터 전송
   const handleLikeClick = i => {
-    const cafeId = sortedCafeList[i].id;
-    const account = ''; //임시
-    console.log(cafeId);
-    fetch(`${process.env.REACT_APP_API_URL}/favorites`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        // token: refreshToken,
-      },
-      body: JSON.stringify({
-        account: account,
-        cafe_id: cafeId,
-      }),
-    })
-      .then(res => res.json())
-      .then(data => {
-        if (data.message === 'ADD_FAVORITES_SUCCESS') {
-          setIsLike(prevLikes => {
-            const newLikes = [...prevLikes];
-            newLikes[i] = !newLikes[i];
-            return newLikes;
-          });
-        } else {
-          console.error('즐겨찾기 추가 실패:', data.message);
-        }
-      })
-      .catch(error => {
-        console.error('통신 에러 :', error);
-      });
+    // const cafeId = sortedCafeList[i].id;
+    // const account = ''; //임시
+    // console.log(cafeId);
+    // fetch(`${process.env.REACT_APP_API_URL}/favorites`, {
+    //   method: 'POST',
+    //   headers: {
+    //     'Content-Type': 'application/json;charset=utf-8',
+    //     // token: refreshToken,
+    //   },
+    //   body: JSON.stringify({
+    //     account: account,
+    //     cafe_id: cafeId,
+    //   }),
+    // })
+    //   .then(res => res.json())
+    //   .then(data => {
+    //     if (data.message === 'ADD_FAVORITES_SUCCESS') {
+    //       setIsLike(prevLikes => {
+    //         const newLikes = [...prevLikes];
+    //         newLikes[i] = !newLikes[i];
+    //         return newLikes;
+    //       });
+    //     } else {
+    //       console.error('즐겨찾기 추가 실패:', data.message);
+    //     }
+    //   })
+    //   .catch(error => {
+    //     console.error('통신 에러 :', error);
+    //   });
+    setIsLike(prevLikes => {
+      const newLikes = [...prevLikes];
+      newLikes[i] = !newLikes[i];
+      return newLikes;
+    });
   };
 
   //좋아요 해제시 백에 데이터 전송

--- a/src/pages/Cafe/SearchCafeList.jsx
+++ b/src/pages/Cafe/SearchCafeList.jsx
@@ -9,29 +9,34 @@ const SearchCafeList = ({ searchCafeData }) => {
 
   //좋아요 클릭시 백에 데이터 전송
   const handleLikeClick = i => {
-    const cafeId = searchCafeData[i].id;
-    const account = '';
-    fetch(`${process.env.REACT_APP_API_URL}/favorites/${cafeId}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        // token: refreshToken,
-      },
-      body: JSON.stringify({
-        account: '', //Q.account가 필요한가? 토큰으로 알 수 있지않나?
-        cafe_id: cafeId,
-      }),
-    }).then(res => {
-      if (res.message === 'ADD_FAVORITES_SUCCESS') {
-        setIsLike(prevLikes => {
-          const newLikes = [...prevLikes];
-          newLikes[i] = !newLikes[i];
-          return newLikes;
-        });
-      } else {
-        console.error('좋아요 기능 실패');
-      }
-    }, []);
+    // const cafeId = searchCafeData[i].id;
+    // const account = '';
+    // fetch(`${process.env.REACT_APP_API_URL}/favorites/${cafeId}`, {
+    //   method: 'POST',
+    //   headers: {
+    //     'Content-Type': 'application/json;charset=utf-8',
+    //     // token: refreshToken,
+    //   },
+    //   body: JSON.stringify({
+    //     account: '', //Q.account가 필요한가? 토큰으로 알 수 있지않나?
+    //     cafe_id: cafeId,
+    //   }),
+    // }).then(res => {
+    //   if (res.message === 'ADD_FAVORITES_SUCCESS') {
+    //     setIsLike(prevLikes => {
+    //       const newLikes = [...prevLikes];
+    //       newLikes[i] = !newLikes[i];
+    //       return newLikes;
+    //     });
+    //   } else {
+    //     console.error('좋아요 기능 실패');
+    //   }
+    // }, []);
+    setIsLike(prevLikes => {
+      const newLikes = [...prevLikes];
+      newLikes[i] = !newLikes[i];
+      return newLikes;
+    });
   };
 
   //좋아요 해제시 백에 데이터 전송

--- a/src/pages/KakaoMaps/kakaoMaps.jsx
+++ b/src/pages/KakaoMaps/kakaoMaps.jsx
@@ -296,19 +296,21 @@ const KakaoMap = () => {
       <div>
         <MapContainer id="map" />
         {isModal && <Loading />}
-        <SearchBar
-          type="text"
-          value={searchInput}
-          onChange={e => setSearchInput(e.target.value)}
-          onKeyPress={handleKeyPress}
-          onClick={() => handleSearch}
-          placeholder="찾으시는 지역명을 입력해주세요"
-        />
-        <SearchIcon
-          src="images/search.png"
-          alt="검색아이콘"
-          onClick={handleSearch}
-        />
+        <SearchBox>
+          <SearchBar
+            type="text"
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
+            onKeyPress={handleKeyPress}
+            onClick={() => handleSearch}
+            placeholder="찾으시는 지역명을 입력해주세요"
+          />
+          <SearchIcon
+            src="images/search.png"
+            alt="검색아이콘"
+            onClick={handleSearch}
+          />
+        </SearchBox>
         {isCurrentBtn && (
           <Button onClick={getCurrentPosBtn}>
             <Icon src="/images/myLocation.png" alt="내 위치" />
@@ -333,17 +335,22 @@ const MapContainer = styled.div`
   height: 450px;
 `;
 
-const SearchBar = styled.input`
+const SearchBox = styled.div`
   position: absolute;
-  background-color: white;
   z-index: 1000;
+  width: 100%;
+  top: 1.3em;
+`;
+
+const SearchBar = styled.input`
+  position: relative;
+  background-color: white;
   left: 10%;
-  top: 1.5%;
 `;
 
 const SearchIcon = styled.img`
   position: absolute;
-  top: 2.3%;
+  top: 25%;
   right: 12%;
   z-index: 1001;
   height: 20px;

--- a/src/pages/KakaoMaps/kakaoMaps.jsx
+++ b/src/pages/KakaoMaps/kakaoMaps.jsx
@@ -7,13 +7,13 @@ import './CustomOverlay.scss';
 
 const KakaoMap = () => {
   const [map, setMap] = useState(null);
-  const [marker, setMarker] = useState(null);
   const [circle, setCircle] = useState(null);
   const [cafeData, setCafeData] = useState([]);
   const [searchInput, setSearchInput] = useState('');
   const [searchCafeData, setSearchCafeData] = useState([]);
   const [isModal, setIsModal] = useState(false);
   const [searchCafeMarkers, setsearchCafeMarkers] = useState([]);
+  const [isCurrentBtn, setIsCurrentBtn] = useState(true);
 
   const handleKeyPress = e => {
     if (e.key === 'Enter') {
@@ -109,6 +109,8 @@ const KakaoMap = () => {
           center: defaultPos,
           level: 5,
         };
+
+        setIsCurrentBtn(false);
 
         const newMap = new window.kakao.maps.Map(container, options);
         newMap.relayout();
@@ -307,9 +309,11 @@ const KakaoMap = () => {
           alt="검색아이콘"
           onClick={handleSearch}
         />
-        <Button onClick={getCurrentPosBtn}>
-          <Icon src="/images/myLocation.png" alt="내 위치" />
-        </Button>
+        {isCurrentBtn && (
+          <Button onClick={getCurrentPosBtn}>
+            <Icon src="/images/myLocation.png" alt="내 위치" />
+          </Button>
+        )}
       </div>
       {searchCafeData.length > 0 ? (
         <SearchCafeList searchCafeData={searchCafeData} />

--- a/src/pages/Like/Like.jsx
+++ b/src/pages/Like/Like.jsx
@@ -8,16 +8,24 @@ import { getCookieToken, removeCookieToken } from '../../Storage/Cookie';
 import { DELETE_TOKEN } from '../../Store/AuthStore';
 
 const Like = ({ setIsRightOpen }) => {
-  const [likes, setLikes] = useState([]);
-  const [userData, setUserData] = useState();
-  const { refreshToken } = getCookieToken();
-
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
+  const [likes, setLikes] = useState([]);
+  const [userData, setUserData] = useState();
+
+  const { refreshToken } = getCookieToken();
+  const { token } = useSelector(state => state.token);
+
   const handleMypageClick = () => {
-    navigate('/mypage');
-    setIsRightOpen(false);
+    //임시 refreshToken
+    if (refreshToken) {
+      navigate('/mypage');
+      setIsRightOpen(false);
+    } else {
+      alert('로그인이 필요합니다.');
+      navigate('/');
+    }
   };
 
   const handleLogout = () => {
@@ -59,14 +67,28 @@ const Like = ({ setIsRightOpen }) => {
   }, []);
 
   //좋아요 한 목록 지우기
-  const handleUnLike = id => {
-    fetch(`${process.env.REACT_APP_API_URL}/favorites/${id}`, {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-        authorization: refreshToken,
-      },
-    });
+  const handleUnLike = cafeId => {
+    // fetch(`${process.env.REACT_APP_API_URL}/favorites/${cafeId}`, {
+    //   method: 'DELETE',
+    //   headers: {
+    //     'Content-Type': 'application/json;charset=utf-8',
+    //     authorization: `Bearer ${token}`,
+    //   },
+    // })
+    //   .then(response => {
+    //     if (response.status === 200) {
+    //       const updatedLikes = likes.filter(info => info.cafe_id !== cafeId);
+    //       setLikes(updatedLikes);
+    //       console.log('카페 삭제 성공!');
+    //     } else {
+    //       console.error('카페 삭제 실패:', response.status);
+    //     }
+    //   })
+    //   .catch(error => {
+    //     console.error('카페 삭제 통신 오류:', error);
+    //   });
+    const updatedLikes = likes.filter(info => info.cafe_id !== cafeId);
+    setLikes(updatedLikes);
   };
 
   return (
@@ -77,8 +99,8 @@ const Like = ({ setIsRightOpen }) => {
         <LogOutBtn onClick={handleLogout}>로그아웃</LogOutBtn>
       </MoveBox>
       <UserLikeBody>
-        {likes.map((info, i) => (
-          <LikeBody key={i}>
+        {likes.map(info => (
+          <LikeBody key={info.cafe_id}>
             <CafeImage src={info.url} />
             <CafeName>{info.name}</CafeName>
             <CafeLocation>{info.address}</CafeLocation>
@@ -88,7 +110,9 @@ const Like = ({ setIsRightOpen }) => {
                 {info.score}
               </ScoreBox>
               <ShareBtn src="images/share.png" alt="공유하기" />
-              <DeleteBtn onClick={() => handleUnLike(i)}>✕</DeleteBtn>
+              <DeleteBtn onClick={() => handleUnLike(info.cafe_id)}>
+                ✕
+              </DeleteBtn>
             </BtnBox>
           </LikeBody>
         ))}

--- a/src/pages/User/FindPassword.jsx
+++ b/src/pages/User/FindPassword.jsx
@@ -36,26 +36,31 @@ const FindPassword = () => {
   };
 
   const setNewPassword = () => {
-    fetch(`${process.env.REACT_APP_API_URL}/users/search`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json;charset=utf-8',
-      },
-      body: JSON.stringify({
-        account: inputValues.account,
-        answer: inputValues.answer,
-        editPassword: inputValues.password,
-      }),
-    }).then(async res => {
-      if (res.message === 'EDIT_PASSWORD_SUCCESS') {
-        alert('비밀번호가 변경되었습니다');
-        return navigate('/');
-      } else {
-        if (res.message === 'wrong answer') {
-          alert('가입시 입력한 초등학교명과 다릅니다.');
+    try {
+      fetch(`${process.env.REACT_APP_API_URL}/users/search`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json;charset=utf-8',
+        },
+        body: JSON.stringify({
+          account: inputValues.account,
+          answer: inputValues.answer,
+          editPassword: inputValues.password,
+        }),
+      }).then(async res => {
+        if (res.message === 'EDIT_PASSWORD_SUCCESS') {
+          alert('비밀번호가 변경되었습니다');
+          return navigate('/');
+        } else {
+          if (res.message === 'wrong answer') {
+            alert('가입시 입력한 초등학교명과 다릅니다.');
+          }
         }
-      }
-    });
+      });
+    } catch (error) {
+      console.error('통신에러:', error);
+      alert('비밀번호 변경에 실패하였습니다.');
+    }
   };
 
   useEffect(() => {

--- a/src/pages/User/FindPassword.jsx
+++ b/src/pages/User/FindPassword.jsx
@@ -4,13 +4,14 @@ import styled from 'styled-components';
 
 const FindPassword = () => {
   const navigate = useNavigate();
-
+  const [passwordError, setPasswordError] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(true);
   const [inputValues, setInputValues] = useState({
     account: '',
     answer: '',
     password: '',
+    password2: '',
   });
-  const [isDisabled, setIsDisabled] = useState(true);
 
   const handleInputValue = e => {
     const { name, value } = e.target;
@@ -18,6 +19,20 @@ const FindPassword = () => {
       ...prevValues,
       [name]: value,
     }));
+  };
+
+  const passwordRegex = /^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[!@#$%^&*])(?=.{8,64})/;
+  const validatePassword = passwordRegex.test(inputValues.password);
+
+  const handleBlur = e => {
+    const { name, value } = e.target;
+    if (name === 'password' && value.length > 0) {
+      if (passwordRegex.test(value) === false) {
+        alert(
+          '비밀번호는 8~64자리로 하나이상의 영문,숫자,특수문자를 포함해야합니다.',
+        );
+      }
+    }
   };
 
   const setNewPassword = () => {
@@ -32,7 +47,7 @@ const FindPassword = () => {
         editPassword: inputValues.password,
       }),
     }).then(async res => {
-      if (res.status === 200) {
+      if (res.message === 'EDIT_PASSWORD_SUCCESS') {
         alert('비밀번호가 변경되었습니다');
         return navigate('/');
       } else {
@@ -44,10 +59,12 @@ const FindPassword = () => {
   };
 
   useEffect(() => {
-    const { account, answer, password } = inputValues;
-    const areInputsFilled = account && answer && password;
-    setIsDisabled(!areInputsFilled);
-  }, [inputValues]);
+    const { account, answer, password, password2 } = inputValues;
+    const areInputsFilled = account && answer && password && password2;
+    const isPasswordMatch = inputValues.password === inputValues.password2;
+    setPasswordError(!isPasswordMatch);
+    setIsDisabled(!(areInputsFilled && isPasswordMatch && validatePassword));
+  }, [inputValues, validatePassword]);
 
   return (
     <BodyBox>
@@ -58,20 +75,32 @@ const FindPassword = () => {
             placeholder="계정을 입력해주세요"
             name="account"
             onChange={handleInputValue}
+            required
           />
           <AnswerInput
             placeholder="졸업한 초등학교의 이름은?"
             name="answer"
             onChange={handleInputValue}
+            required
           />
           <PasswordInput
+            onBlur={handleBlur}
             name="password"
             placeholder="신규 비밀번호를 입력해주세요"
             onChange={handleInputValue}
+            hasError={passwordError}
+            required
+          />
+          <PasswordInput
+            name="password2"
+            placeholder="동일한 비밀번호를 입력해주세요"
+            onChange={handleInputValue}
+            hasError={passwordError}
+            required
           />
         </InputBox>
         <FindPasswordBtn onClick={setNewPassword} disabled={isDisabled}>
-          저장
+          변경하기
         </FindPasswordBtn>
         <Link to="/">
           <GotoMain>메인페이지로</GotoMain>
@@ -99,7 +128,7 @@ const BodyBox = styled.div`
 `;
 
 const FindName = styled.h1`
-  padding-top: 0.5em;
+  padding: 0.5em 0;
   font-size: 1.6em;
   color: ${props => props.theme.mainColor};
 `;
@@ -114,7 +143,7 @@ const FindPasswordBox = styled.div`
   border-radius: 0.5em;
   padding: 1em;
   width: 23em;
-  height: 21em;
+  height: 24em;
   flex-direction: column;
   margin: 0 auto;
   align-items: center;
@@ -126,14 +155,16 @@ const InputBox = styled.div`
   justify-content: space-evenly;
   align-items: center;
   width: 100%;
-  height: 10em;
+  height: 13em;
 `;
 
 const AccountInput = styled.input``;
 
 const AnswerInput = styled.input``;
 
-const PasswordInput = styled.input``;
+const PasswordInput = styled.input`
+  border-color: ${props => (props.hasError ? 'red' : '#d5d5d5')};
+`;
 
 const FindPasswordBtn = styled.button`
   width: 80%;

--- a/src/pages/User/Login.jsx
+++ b/src/pages/User/Login.jsx
@@ -55,7 +55,7 @@ const TestLogin = ({ setIsRightOpen }) => {
       if (res.status === 200) {
         const data = await res.json();
         setRefreshToken(data.refresh_token);
-        dispatch(SET_TOKEN(data.access_token));
+        dispatch(SET_TOKEN(data.accessToken));
         return navigate('/');
       }
     });

--- a/src/pages/User/Login.jsx
+++ b/src/pages/User/Login.jsx
@@ -5,7 +5,6 @@ import { SET_TOKEN } from '../../Store/AuthStore';
 import { setRefreshToken } from '../../Storage/Cookie';
 import { useDispatch } from 'react-redux';
 import Signup from './Signup';
-import FindPassword from './FindPassword';
 
 const fadeIn = keyframes`
 from {

--- a/src/pages/User/Signup.jsx
+++ b/src/pages/User/Signup.jsx
@@ -6,6 +6,8 @@ const Signup = ({ setIsRightOpen }) => {
   const navigate = useNavigate();
   const [isDisabled, setIsDisabled] = useState(true);
   const [passwordError, setPasswordError] = useState(false);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isValid, setIsValid] = useState(false);
   const [inputValues, setInputValues] = useState({
     account: '',
     nickname: '',
@@ -13,6 +15,11 @@ const Signup = ({ setIsRightOpen }) => {
     password2: '',
     question: '',
   });
+
+  const accountRegex = /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{3,30}$/;
+  const passwordRegex = /^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[!@#$%^&*])(?=.{8,64})/;
+  const validateAccount = accountRegex.test(inputValues.account);
+  const validatePassword = passwordRegex.test(inputValues.password);
 
   const handleInputValue = e => {
     const { name, value } = e.target;
@@ -22,8 +29,45 @@ const Signup = ({ setIsRightOpen }) => {
     }));
   };
 
+  const handleBlur = e => {
+    const { name, value } = e.target;
+
+    if (name === 'password' && value.length > 0) {
+      if (passwordRegex.test(value) === false) {
+        alert(
+          '비밀번호는 8~64자리로 하나이상의 영문,숫자,특수문자를 포함해야합니다.',
+        );
+      }
+    }
+  };
+
+  const accountCheck = () => {
+    if (accountRegex.test(inputValues.account)) {
+      setIsValid(true);
+      // fetch(`process.env.API_URL/users/duplicationCheck/{inputValues.account}`, {
+      //   method: 'GET',
+      //   headers: {
+      //     'Content-Type': 'application/json;charset=utf-8',
+      //   },
+      // })
+      //   .then(res => res.json())
+      //   .then(data => {
+      //     if (data.message === 'ACCOUNT ALREADY EXIST') {
+      //       alert('이미 존재하는 id입니다.');
+      //     } else {
+      //       alert('사용 가능한 id입니다.');
+      //     }
+      //   });
+    } else {
+      setIsValid(false);
+      alert('ID는  3~30자리 영문 숫자로 입력해주세요.');
+    }
+  };
+
   useEffect(() => {
     const isPasswordMatch = inputValues.password === inputValues.password2;
+    setPasswordError(!isPasswordMatch);
+
     const isAllInputsFilled =
       inputValues.account &&
       inputValues.nickname &&
@@ -31,9 +75,15 @@ const Signup = ({ setIsRightOpen }) => {
       inputValues.password2 &&
       inputValues.question;
 
-    setIsDisabled(!(isAllInputsFilled && isPasswordMatch));
-    setPasswordError(!isPasswordMatch);
-  }, [inputValues]);
+    setIsDisabled(
+      !(
+        isAllInputsFilled &&
+        isPasswordMatch &&
+        validateAccount &&
+        validatePassword
+      ),
+    );
+  }, [inputValues, validateAccount, validatePassword]);
 
   const addUser = () => {
     fetch(`${process.env.REACT_APP_API_URL}/users/signup`, {
@@ -59,35 +109,50 @@ const Signup = ({ setIsRightOpen }) => {
       <SignupBox>
         <Logo>회원가입</Logo>
         <SignupForm>
-          <AccountInput
-            name="account"
-            value={inputValues.account}
-            onChange={handleInputValue}
-            placeholder="사용할 id를 입력해주세요"
-            required
-          />
+          <AccountBox>
+            <AccountInput
+              name="account"
+              value={inputValues.account}
+              onChange={handleInputValue}
+              placeholder="id를 입력해주세요"
+              required
+            />
+            <CheckAccountBtn onClick={() => accountCheck()}>
+              중복확인
+            </CheckAccountBtn>
+          </AccountBox>
+
           <NicknameInput
             name="nickname"
             value={inputValues.nickname}
             onChange={handleInputValue}
-            placeholder="사용할 닉네임을 입력해주세요"
+            placeholder="닉네임을 입력해주세요"
             required
           />
-          <PasswordInput
-            name="password"
-            type="password"
-            value={inputValues.password}
-            onChange={handleInputValue}
-            placeholder="비밀번호를 입력해주세요"
-            required
-            hasError={passwordError}
-          />
+
+          <PasswordBox>
+            <PasswordInput
+              name="password"
+              type={isPasswordVisible ? 'text' : 'password'}
+              value={inputValues.password}
+              onChange={handleInputValue}
+              placeholder="비밀번호를 입력해주세요"
+              required
+              hasError={passwordError}
+              onBlur={handleBlur}
+            />
+            <PasswordVisibieButton
+              onClick={() => setIsPasswordVisible(!isPasswordVisible)}
+            >
+              {isPasswordVisible ? '숨기기' : '보기'}
+            </PasswordVisibieButton>
+          </PasswordBox>
           <PasswordInput
             name="password2"
-            type="password"
+            type={isPasswordVisible ? 'text' : 'password'}
             value={inputValues.password2}
             onChange={handleInputValue}
-            placeholder="비밀번호를 다시 입력해주세요"
+            placeholder="비밀번호 재입력"
             required
             hasError={passwordError}
           />
@@ -149,12 +214,46 @@ const SignupForm = styled.div`
   grid-gap: 0.6em;
 `;
 
+const AccountBox = styled.div`
+  width: 100%;
+  position: relative;
+`;
+
 const AccountInput = styled.input``;
+
+const CheckAccountBtn = styled.button`
+  width: 4.6em;
+  height: 2.57em;
+  color: ${props => props.theme.mainColor};
+  position: absolute;
+  top: 0;
+  right: 10%;
+  font-size: 0.9em;
+  border: 1px solid #d5d5d5;
+`;
 
 const NicknameInput = styled.input``;
 
+const PasswordBox = styled.div`
+  width: 100%;
+  position: relative;
+`;
+
 const PasswordInput = styled.input`
   border-color: ${props => (props.hasError ? 'red' : '#d5d5d5')};
+`;
+
+const PasswordVisibieButton = styled.button`
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  width: 4.6em;
+  height: 2.57em;
+  color: ${props => props.theme.mainColor};
+  position: absolute;
+  top: 0;
+  right: 10%;
+  font-size: 0.9em;
 `;
 
 const QuestionInput = styled.input``;


### PR DESCRIPTION
# 1. 구현한 것.
1. 회원가입시 유효성 검사기능 추가
  - api 요청을 하지않고 버튼도 누르지않고 유효성 검사를 할 수 있는 방법이 뭐가 있을까 고민하다가 onBlur를 알게되었다. input을 벗어나자마자 함수가 작동하는데 id,pw,pw2에  적용하니 사용자가 불편하다고 느낄거같아 password에만 적용.
  - password와 재입력 password2가 일치하지않으면 빨간 테두리로 바뀜.
2. 계정 중복확인 
 -  id의 유효성 검사의 경우 중복확인 버튼을 눌렀을때 검사를 통과하지못하면 api 요청을 보내지않고 경고를 뜨게함. 검사통과시 api 요청.
 - 닉네임 중복확인과 계정 중복확인 이있었으나 확인 버튼이 너무 많아서 닉네임은 논의하여 중복되도록 ERD를 바꿈.
 3. 모든 조건이 충족되지 않으면 버튼이 비활성화.
 4. 좋아요 버튼 함수 수정
 
# 2. 어려웠던 점
- 백으로 유효성 검사를 했을때는 regex를 사용해서 검증하는 코드를 만들고  들어온 값과 맞지않으면 오류메시지를 보내도록 단순한 함수를 만들었었는데, 프론트는 유효성 검증을 하고 조건에 맞지않으면 사용자가 알수있도록 화면을 변화시키는게 생각보다 어려웠다.